### PR TITLE
67b sparse arrays

### DIFF
--- a/crustal_sz_shared_scripts/09_run_compare_fault_branches.py
+++ b/crustal_sz_shared_scripts/09_run_compare_fault_branches.py
@@ -139,7 +139,7 @@ for name in model_subdirectory_dict.keys():
 outfile_directory = f"{results_directory}/compare_fault_models/{dir_name}"
 if not os.path.exists(f"../{outfile_directory}"):
         os.makedirs(f"../{outfile_directory}", exist_ok=True)
-file_name = file_id + '_' + sigma_lims
+file_name = (file_id + '_' + sigma_lims).strip('_')
 
 pretty_site_names = []
 if plot_order_name == "from_csv":

--- a/crustal_sz_shared_scripts/probabalistic_displacement_scripts.py
+++ b/crustal_sz_shared_scripts/probabalistic_displacement_scripts.py
@@ -1115,9 +1115,9 @@ def create_site_weighted_mean(site_h5, site, n_samples, crustal_directory, sz_di
             site_max_probs = site_probabilities_df.max(axis=1)
             site_min_probs = site_probabilities_df.min(axis=1)
 
-            site_h5.create_dataset(f"weighted_exceedance_probs_{exceed_type}", data=branch_weighted_mean_probs, compression=compression)
-            site_h5.create_dataset(f"{exceed_type}_max_vals", data=site_max_probs, compression=compression)
-            site_h5.create_dataset(f"{exceed_type}_min_vals", data=site_min_probs, compression=compression)
+            site_h5.create_dataset(f"weighted_exceedance_probs_{exceed_type}", data=branch_weighted_mean_probs[branch_weighted_mean_probs > 0], compression=compression)
+            site_h5.create_dataset(f"{exceed_type}_max_vals", data=site_max_probs[site_max_probs > 0], compression=compression)
+            site_h5.create_dataset(f"{exceed_type}_min_vals", data=site_min_probs[site_min_probs > 0], compression=compression)
             site_h5.create_dataset(f"branch_exceedance_probs_{exceed_type}", data=site_probabilities_df.to_numpy(), compression='gzip', compression_opts=6)
             site_h5[f'branch_exceedance_probs_{exceed_type}'].attrs['branch_ids'] = pair_id_list
 

--- a/crustal_sz_shared_scripts/probabalistic_displacement_scripts.py
+++ b/crustal_sz_shared_scripts/probabalistic_displacement_scripts.py
@@ -327,7 +327,7 @@ def get_cumu_PPE(slip_taper, model_version_results_directory, branch_site_disp_d
     # get displacement thresholds for calculating exceedance (hazard curve x-axis)
     thresholds = np.round(np.arange(thresh_lims[0], thresh_lims[1] + thresh_step, thresh_step), 4)
 
-    benchmarking = True
+    benchmarking = False
     start = time()
     if not benchmarking:
         printProgressBar(0, len(site_ids), prefix=f'\tProcessing {len(site_ids)} Sites:', suffix='Complete 00:00:00 (00:00s/site)', length=50)

--- a/crustal_sz_shared_scripts/probabalistic_displacement_scripts.py
+++ b/crustal_sz_shared_scripts/probabalistic_displacement_scripts.py
@@ -250,7 +250,7 @@ def prepare_random_arrays(branch_site_disp_dict_file, randdir, time_interval, n_
 
 
 def get_cumu_PPE(slip_taper, model_version_results_directory, branch_site_disp_dict, site_ids, n_samples,
-                 extension1, branch_key="nan", time_interval=100, sd=0.4, error_chunking=10000, scaling='', load_random=False,
+                 extension1, branch_key="nan", time_interval=100, sd=0.4, error_chunking=1000, scaling='', load_random=False,
                  thresh_lims=[0, 3], thresh_step=0.01, plot_maximum_displacement=False, array_process=False,
                  crustal_model_dir="", subduction_model_dirs="", NSHM_branch=True, pair_unique_id=None):
     """

--- a/crustal_sz_shared_scripts/run_aggregate_weighted_branches.py
+++ b/crustal_sz_shared_scripts/run_aggregate_weighted_branches.py
@@ -73,7 +73,7 @@ if testing:
     job_time = 1    # Amount of time to allocate per site in the cumu_PPE task array
     mem = 1    # Memory allocation for cumu_PPE task array
 else:
-    n_samples = 1e5   # Number of scenarios to run
+    n_samples = 1e6   # Number of scenarios to run
     job_time = 3    # Amount of time to allocate per site in the cumu_PPE task array
     mem = 3    # Memory allocation for cumu_PPE task array
 

--- a/crustal_sz_shared_scripts/single_branch_plotting.py
+++ b/crustal_sz_shared_scripts/single_branch_plotting.py
@@ -57,7 +57,7 @@ def get_mean_disp_barchart_data(site_PPE_dictionary, probability, exceed_type, s
 
         # probability values at each threshold
         site_mean_probs = site_PPE_dictionary[site][f"exceedance_probs_{exceed_type}"]
-        smin, smax = get_sigma_lims(site_PPE_dictionary[site]['sigma_lims'][:], sig_lim=sig_lim)
+        smin, smax, _ = get_sigma_lims(site_PPE_dictionary[site]['sigma_lims'][:], sig_lim=sig_lim)
         max_probs = site_PPE_dictionary[site][f"error_{exceed_type}"][smax, :]
         min_probs = site_PPE_dictionary[site][f"error_{exceed_type}"][smin, :]
 
@@ -118,7 +118,7 @@ def get_mean_prob_plot_data(site_PPE_dictionary, threshold, exceed_type, site_li
         except IndexError:
             probs.append(0)
 
-        smin, smax = get_sigma_lims(site_PPE_dictionary[site]['sigma_lims'][:], sig_lim=sig_lim)
+        smin, smax, _ = get_sigma_lims(site_PPE_dictionary[site]['sigma_lims'][:], sig_lim=sig_lim)
         try:
             max_prob = site_PPE_dictionary[site][f"error_{exceed_type}"][smax, probs_index]
             min_prob = site_PPE_dictionary[site][f"error_{exceed_type}"][smin, probs_index]


### PR DESCRIPTION
Sparse arrays only needed for saving the scenario rates - means that displacement uncertainties don't need to be saved and can be calculated on the fly.
Additionally, it's _sooooooo_ much faster now